### PR TITLE
PB-39283 Don't use default time based expiry

### DIFF
--- a/sdk/SDK.Examples/src/UpdatePackageExample.cs
+++ b/sdk/SDK.Examples/src/UpdatePackageExample.cs
@@ -60,7 +60,7 @@ namespace SDK.Examples
         public readonly string NEW_PACKAGE_NAME = "new package name";
         public readonly string NEW_DESCRIPTION = "new description";
         public readonly string NEW_EMAIL_MESSAGE = "new email message";
-        public readonly DateTime NEW_EXPIRY_DATE = DateTime.Now.AddMonths(2);
+        public readonly DateTime NEW_EXPIRY_DATE = DateTime.Now.AddMonths(1);
         public readonly CultureInfo NEW_LANGUAGE = CultureInfo.GetCultureInfo("fr");
 
         public readonly Visibility NEW_VISIBILITY = Visibility.SENDER;
@@ -104,6 +104,7 @@ namespace SDK.Examples
                     .WithOptOutReason(OLD_OPT_OUT_REASON_3)
                     .WithWatermark()
                     .WithCeremonyLayoutSettings(layoutSettingsToCreate)
+                    .WithoutDefaultTimeBasedExpiry()
                     .Build();
             
             packageToCreate = PackageBuilder.NewPackageNamed(OLD_PACKAGE_NAME)
@@ -155,6 +156,7 @@ namespace SDK.Examples
                     .WithOptOutReason(NEW_OPT_OUT_REASON_3)
                     .WithoutWatermark()
                     .WithCeremonyLayoutSettings(layoutSettingsToUpdate)
+                    .WithoutDefaultTimeBasedExpiry()
                     .Build();
 
             packageToUpdate = PackageBuilder.NewPackageNamed( NEW_PACKAGE_NAME )


### PR DESCRIPTION
When setting package expiry as a date it's important to set "defaultTimeBasedExpirty" to false
so that the date won't get overwritten with the default "number of days" based value.